### PR TITLE
Fix typo in RIGHT JOIN boilerplate

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ Let's take a look a boiler-plate RIGHT OUTER JOIN query:
 ```sql
 SELECT column_name(s)
 FROM first_table
-RIGHT JOIN table2
+RIGHT JOIN second_table
 ON first_table.column_name = second_table.column_name;
 ```
 


### PR DESCRIPTION
Since SQLite does not currently support RIGHT JOIN this is likely no cause for concern, but maybe worth an update for consistency's sake in a future RIGHT JOIN inclusive world 😄